### PR TITLE
lock in versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/YaleDHLab/gathering-a-building#readme",
   "dependencies": {
-    "angular-route": "^1.5.8",
+    "angular-route": "1.5.8",
     "angular-sanitize": "^1.5.8",
     "angularjs-slider": "^5.5.1",
     "font-awesome": "^4.6.3",
@@ -45,7 +45,7 @@
     "superagent": "^2.3.0"
   },
   "devDependencies": {
-    "angular": "^1.5.8",
+    "angular": "1.5.8",
     "async": "^2.0.1",
     "autoprefixer-loader": "^3.2.0",
     "babel-core": "^6.14.0",


### PR DESCRIPTION
To prevent from upgrading to angular-router 1.6, which introduces breaking changes